### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,6 @@ Usage
 .. |coverage| image:: http://coveralls.io/repos/Pentusha/cinemate/badge.svg?branch=master
    :alt: Tests Coverage
    :target: https://coveralls.io/r/Pentusha/css_classes
-.. |wheel| image:: http://pypip.in/wheel/css_classes/badge.svg?style=flat
+.. |wheel| image:: https://img.shields.io/pypi/wheel/css_classes.svg?style=flat
    :alt: Wheel Status
    :target: https://pypi.python.org/pypi/css_classes/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20css-classes))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `css-classes`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.